### PR TITLE
test_whitebox: remove extraneous import, set executable bit on test-cov.sh

### DIFF
--- a/tests/test_whitebox.py
+++ b/tests/test_whitebox.py
@@ -2,7 +2,6 @@ import RPi.GPIO as GPIO
 import RPi.GPIO_DEVEL as GPIO_DEVEL
 import pytest
 import re
-import os
 
 def foo():
     pass


### PR DESCRIPTION
Signed-off-by: Joel Savitz <joelsavitz@gmail.com>