### PR TITLE
add pull up/pull down resistor support, rework constant handling, and more

### DIFF
--- a/RPi/GPIO/__init__.py
+++ b/RPi/GPIO/__init__.py
@@ -1,4 +1,7 @@
-# Interface functions (1-2) exposed constants (3)
+# The extended RPi.GPIO API
 from RPi._GPIO import setup, cleanup, output, input, setmode, getmode, add_event_detect, remove_event_detect, event_detected, \
     add_event_callback, wait_for_edge, gpio_function, setwarnings, \
-    BCM, BOARD, UNKNOWN, IN, OUT, RISING, FALLING, BOTH, PUD_UP, PUD_DOWN, PUD_OFF, HIGH, LOW
+    getbias, setbias, getdirection, setdirection, getactive_state, setactive_state, \
+    channel_valid_or_die, \
+    BCM, BOARD, UNKNOWN, IN, OUT, RISING, FALLING, BOTH, PUD_UP, PUD_DOWN, PUD_OFF, PUD_DISABLE, \
+    HIGH, LOW

--- a/test-style.sh
+++ b/test-style.sh
@@ -22,3 +22,6 @@ scan() {
 
 scan RPi/_GPIO.py
 scan tests/test_whitebox.py
+
+scan RPi/GPIO/__init__.py
+scan RPi/GPIO_DEVEL/__init__.py

--- a/tests/test_whitebox.py
+++ b/tests/test_whitebox.py
@@ -66,7 +66,12 @@ def test_getmode():
 
 def test_validate_pin_or_die():
     GPIO_DEVEL.Reset()
-    pass    
+    GPIO.setmode(GPIO.BOARD)
+    with pytest.raises(ValueError):
+        channel = GPIO.channel_valid_or_die(-666)
+
+    with pytest.raises(ValueError):
+        channel = GPIO.channel_valid_or_die(1)
 
 
 def test_setmode():
@@ -357,3 +362,115 @@ def test_setdebuginfo():
     GPIO_DEVEL.setdebuginfo(True)
 
     assert GPIO_DEVEL.State_Access().debuginfo == True
+
+def test_bias():
+    GPIO_DEVEL.Reset()
+
+    GPIO.setmode(GPIO.BCM)
+
+    GPIO.setup(18, GPIO.IN , GPIO.PUD_UP)
+
+    assert GPIO.getbias(13) == GPIO.PUD_OFF
+    assert GPIO.getbias(18) == GPIO.PUD_UP
+
+    GPIO.setup(19, GPIO.IN , GPIO.PUD_DOWN)
+    assert GPIO.getbias(19) == GPIO.PUD_DOWN
+
+    GPIO.setup(20, GPIO.IN , GPIO.PUD_DISABLE)
+    assert GPIO.getbias(20) == GPIO.PUD_DISABLE
+
+    # Default behavior
+    GPIO.setup(21, GPIO.IN)
+    assert GPIO.getbias(21) == GPIO.PUD_OFF
+
+
+def test_getset_direction():
+    GPIO_DEVEL.Reset()
+
+    GPIO.setmode(GPIO.BCM)
+
+    GPIO.setup(18, GPIO.IN , GPIO.PUD_UP)
+
+    assert GPIO.getdirection(18) == GPIO.IN
+
+    GPIO.add_event_detect(18, GPIO.FALLING, foo, 1)
+    GPIO.setdirection(18, GPIO.OUT)
+
+    assert GPIO.getdirection(18) == GPIO.OUT
+
+    GPIO.setdirection(18, GPIO.OUT)
+
+    assert GPIO.getdirection(18) == GPIO.OUT
+
+    GPIO.setdirection(18, GPIO.IN)
+
+    assert GPIO.getdirection(18) == GPIO.IN
+
+    GPIO.setdirection(18, GPIO.IN)
+
+    assert GPIO.getdirection(18) == GPIO.IN
+
+    with pytest.raises(ValueError):
+        GPIO.setdirection(18, "random string")
+
+    # sensible default for inactive channel
+    assert GPIO.getdirection(5) == -1
+
+
+def test_getset_bias():
+    GPIO_DEVEL.Reset()
+
+    GPIO.setmode(GPIO.BCM)
+
+    GPIO.setup(18, GPIO.IN , GPIO.PUD_UP)
+
+    assert GPIO.getbias(18) == GPIO.PUD_UP
+
+    GPIO.setbias(18, GPIO.PUD_UP)
+
+    assert GPIO.getbias(18) == GPIO.PUD_UP
+
+    GPIO.setbias(18, GPIO.PUD_DOWN)
+
+    assert GPIO.getbias(18) == GPIO.PUD_DOWN
+
+    GPIO.setbias(18, GPIO.PUD_OFF)
+
+    assert GPIO.getbias(18) == GPIO.PUD_OFF
+
+    GPIO.setbias(18, GPIO.PUD_DISABLE)
+
+    assert GPIO.getbias(18) == GPIO.PUD_DISABLE
+
+    GPIO.setbias(18, GPIO.PUD_UP)
+
+    assert GPIO.getbias(18) == GPIO.PUD_UP
+
+    with pytest.raises(ValueError):
+        GPIO.setbias(18, "random string")
+
+    # sensible default for inactive channel
+    assert GPIO.getbias(5) == GPIO.PUD_OFF
+
+def test_getset_active_state():
+    GPIO_DEVEL.Reset()
+
+    GPIO.setmode(GPIO.BCM)
+
+    GPIO.setup(18, GPIO.IN, GPIO.PUD_UP)
+
+    assert GPIO.getactive_state(18) == GPIO.HIGH
+
+    GPIO.setactive_state(18, GPIO.HIGH)
+
+    assert GPIO.getactive_state(18) == GPIO.HIGH
+
+    GPIO.setactive_state(18, GPIO.LOW)
+
+    assert GPIO.getactive_state(18) == GPIO.LOW
+
+    with pytest.raises(ValueError):
+        GPIO.setactive_state(18, "random string")
+
+    # sensible default for inactive channel
+    assert GPIO.getdirection(5) == -1


### PR DESCRIPTION
This patch includes the following:
	- Modify constants to transparently expose underlying libgpiod constants
	- Expose channel_fix_and_validate to API as channel_valid_or_die
	- Add support for pull down and pull up resistors reflective of RPi.GPIO behavior
	- [NEW] Extend RPi.GPIO API to support PUD_DISABLE mode using underlying libgpiod capability
	- [NEW] Extend RPi.GPIO API to expose getters and setters for line properties of:
		- direction (IN, OUT)
		- bias (PUD_UP, PUD_DOWN, PUD_OFF, PUD_DISABLE)
		- active_state (ACTIVE_HIGH, ACTIVE_LOW)
	- include \_\_init\_\_.py files in RPi directory in style check
	- extend whitebox tests to cover new codepaths
	- test coverage: 95%

Signed-off-by: Joel Savitz <joelsavitz@gmail.com>

fixes #5 