### PR TITLE
Fix concurrecy issues, refactor internal interface

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-	ignore = E221, F401
+	ignore = E221, F401, E241, E265
 	max-line-length = 140
 	exclude = tests/*, examples/*, misc/*

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ This project implements a compatibility layer between RPi.GPIO syntax and libgpi
 
 RPi.GPIO requires non-standard kernel patches that expose the GPIO registers to userspace via
 a character device `/dev/gpiomem`. As this is not supported by the mainline Linux kernel, any
-disribution targeting Raspberry Pi devices running the mainline kernel will not be compatible
+distribution targeting Raspberry Pi devices running the mainline kernel will not be compatible
 with the RPi.GPIO library. As a large number of tutorials, especially those targeted at
 beginners, demonstrate use of the RPi's GPIO pins by including RPi.GPIO syntax, this
-incompatibility limits users to distributions build on a special downsteam kernel maintained
+incompatibility limits users to distributions build on a special downstream kernel maintained
 by the Rapberry Pi foundation. We would like to enable beginners on any Linux distribution
 by allowing them to follow easily available tutorials.
 
 #### Solution:
 Using the provided module, one will be able to write python code to use the Raspberry Pi's
-GPIO pins as if they were using the API imlpemented by RPi.GPIO, but instead using
+GPIO pins as if they were using the API implemented by RPi.GPIO, but instead using
 libgpiod's python bindings. libgpiod provides a straightforward interface for interacting
 with GPIO pins on supported devices via the mainline Linux kernel interface.
 

--- a/RPi/GPIO_DEVEL/__init__.py
+++ b/RPi/GPIO_DEVEL/__init__.py
@@ -1,2 +1,3 @@
 # Development functions, not needed for normal use
-from RPi._GPIO import Reset, State_Access, setdebuginfo, is_all_ints, is_all_bools, is_iterable
+from RPi._GPIO import Reset, State_Access, setdebuginfo, is_all_ints, is_all_bools, is_iterable, \
+    line_get_mode, line_set_mode, _line_mode_none, _line_mode_out, _line_mode_in

--- a/examples/callback2.py
+++ b/examples/callback2.py
@@ -1,0 +1,10 @@
+# Daniel's example (reproduced bug 6)
+import RPi.GPIO as GPIO
+import time
+def callback_one(pin):
+    print("CALLBACK")
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(21, GPIO.IN, GPIO.PUD_OFF)
+GPIO.add_event_detect(21, GPIO.RISING, callback_one, 1)
+input()
+GPIO.cleanup()

--- a/misc/README
+++ b/misc/README
@@ -3,3 +3,5 @@ apparently permanent network crash by requesting access
 to a GPIO responsible for that interface
 
 TODO: figure out what to do with this information
+
+NOTE: Should our library protect the user from themselves here?


### PR DESCRIPTION
```
changelog:
	main:
	- modularize validation done in API and internal state changes
	- implement locking on a per-line basis:
		- add {begin,end}_critical_section() as simple interface
		- internally rely on lock within _Line instances in _State.lines
	- refactor internal state representation:
		- lines now kept as _Line objects
		- these _Lines may contain _PollThreads
		- _PollThreads inherit Thread and contain a killswitch event
		- minimal object oriented interface
		- add many line_* and chip_* interface functions
	- introduce line modes:
		- connecte RPi.GPIO constants with libgpiod equivalents
		- simple set/get abstractions for state changes
	- initialize library with call to Reset
	- refactor Reset:
		- cleanup()->chip_destroy() gets locks on _all_ channels
		- this is now exactly how library is intialized
	- make validate_gpio_dev_exists() idemotent

	tests:
	- import time
	- tweak dummy function
	- remove test for warnings that are not currently supported
	- tweak whitebox assertions for refactored library
	- greatly enhance rigor of tests of add_event_detect()
	- add test for cleanup

	other:
        - flake8: ignore E241 and E265
        - readme: fix typos
        - GPIO_DEVEL: partially expose line mode data for testing
        - examples: add reproducer for Daniel's bug (#6) as working example
        - misc/README: add note
```
fixes #6 

Signed-off-by: Joel Savitz <joelsavitz@gmail.com>