### PR TITLE
Expose mistakenly unexposed RPi.GPIO.SERIAL constant

### DIFF
--- a/RPi/GPIO/__init__.py
+++ b/RPi/GPIO/__init__.py
@@ -24,6 +24,7 @@ from RPi.core import\
     RISING,\
     RPI_INFO,\
     RPI_REVISION,\
+    SERIAL,\
     SPI,\
     UNKNOWN,\
     VERSION,\


### PR DESCRIPTION
This enables exception-free transparent execution of `import gpiozero.pins.rpigpio as rpigpio`

fixes #37

Signed-off-by: Joel Savitz <joelsavitz@gmail.com>