### PR TITLE
Add checking if the new node is not the same as original mode in the setmode function

### DIFF
--- a/RPi/core.py
+++ b/RPi/core.py
@@ -1046,7 +1046,7 @@ def setmode(mode):
         BOARD - Use Raspberry Pi board numbers
         BCM   - Use Broadcom GPIO 00..nn numbers
     """
-    if _State.mode != UNKNOWN:
+    if _State.mode != UNKNOWN and _State.mode != mode:
         raise ValueError("A different mode has already been set!")
 
     if mode != BCM and mode != BOARD:

--- a/tests/test_gpio.py
+++ b/tests/test_gpio.py
@@ -41,6 +41,16 @@ def test_is_iterable():
         assert GPIO_DEVEL.is_iterable(i) is True
 
 
+@pytest.mark.parametrize('GPIO_MODE', [GPIO.BCM, GPIO.BOARD])
+def test_setmode_remain_silent_in_same_mode(GPIO_MODE):
+    GPIO_DEVEL.Reset()
+    GPIO.setmode(GPIO_MODE)  # Set a mode first
+    try:
+        GPIO.setmode(GPIO_MODE)  # Expect there is not exception being raised
+    except ValueError:
+        pytest.fail('Failed to due double setup')
+
+
 def test_setmode_raise_double_setup_exception():
     GPIO_DEVEL.Reset()
     with pytest.raises(Exception):


### PR DESCRIPTION
I added the checking of whether the new mode and the original mode are the same or not in the `setmode` function. If both of the modes are the same, it's regarded as a normal behavior.
I have checked the original RPi.GPIO source code, there is similar checking mechanism in the `setmode` function.